### PR TITLE
ACM-7673 move service monitor to ACM namespace

### DIFF
--- a/stable/insights-chart/templates/policyreport-servicemonitor.yaml
+++ b/stable/insights-chart/templates/policyreport-servicemonitor.yaml
@@ -5,7 +5,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: acm-{{ .Values.insights.name }}
-  namespace: openshift-monitoring
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Values.insights.name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-7673
Description of changes

move servicemonitors from openshift-monitoring namespace to open-cluster-management namespace.
